### PR TITLE
Add recipe.preproc.macros

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -82,6 +82,9 @@ recipe.size.regex=^(?:\.text|\.data|\.bootloader)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
+## Preprocessor
+preproc.macros.flags=-w -x c++ -E -CC
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------


### PR DESCRIPTION
Copy `preproc.macros.flags` and `recipe.preproc.macros` from the Arduino AVR Boards 1.6.9 platform.txt. This solves the issue of the MCU specific macros not being correctly handled by the preprocessor. in Arduino IDE 1.6.6 and 1.6.7(https://github.com/arduino/Arduino/issues/4617). See https://github.com/arduino/arduino-builder/issues/106 for more information on the cause of this issue. Note that I did not copy [`preproc.includes.flags`](https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/platform.txt#L85) and [`recipe.preproc.includes`](https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/platform.txt#L86) as they are not relevant to arduino/Arduino#4617.
